### PR TITLE
fix: No overload matches this call

### DIFF
--- a/src/components/BotMessageWithBodyInput.tsx
+++ b/src/components/BotMessageWithBodyInput.tsx
@@ -7,7 +7,7 @@ import {StartingPageAnimatorProps} from "./CustomChannelComponent";
 import {DemoConstant} from "../const";
 import {DemoStatesContext} from "../context/DemoStatesContext";
 
-const Root = styled.div<StartingPageAnimatorProps>`
+const Root = styled.div`
   display: flex;
   align-items: flex-end;
   margin-bottom: 6px;

--- a/src/components/StartingPage.tsx
+++ b/src/components/StartingPage.tsx
@@ -10,7 +10,7 @@ import {useImageLoadingState} from "../context/ImageLoadingStateContext";
 
 
 
-const BackgroundContainer = styled.div<StartingPageAnimatorProps>`
+const BackgroundContainer = styled.div`
   position: absolute;
 `;
 


### PR DESCRIPTION
Root and background container  doesn't need 
`isStartingPage: boolean;` from StartingPageAnimatorProps 